### PR TITLE
Fixes typo in xp_compute "=" instead of "=="

### DIFF
--- a/fight.c
+++ b/fight.c
@@ -3714,7 +3714,7 @@ int xp_compute( CHAR_DATA *gch, CHAR_DATA *victim, int total_levels )
         xp += (int) mxp;
     }
 
-    axp == get_addict_bonus(gch, base_exp);
+    axp = get_addict_bonus(gch, base_exp);
     xp += axp;
 
     if (IS_DEBUGGING(gch))


### PR DESCRIPTION
May be causing the 1exp bug.