### PR TITLE
Tribe remort checks for black fury and red talon (closes #299)

### DIFF
--- a/garou.c
+++ b/garou.c
@@ -372,6 +372,11 @@ void do_gogarou(CHAR_DATA *ch, char *argument)
         }
         else if(!str_prefix( argument, "red talons") || !str_prefix( argument, "red talon"))
         {
+            if (ch->pcdata->breed != LUPUS)
+            {
+                send_to_char("You must be born from a wolf to join the Red Talons.\n\r", ch);
+                return;
+            }
             send_to_char("Alright. You are now a Red Talon.\n\r",ch);
             ch->pcdata->tribe = RED_TALON;
             ch->clan = clan_lookup("redtalon");

--- a/garou.c
+++ b/garou.c
@@ -337,6 +337,11 @@ void do_gogarou(CHAR_DATA *ch, char *argument)
         }
         if(!str_prefix( argument, "black furies") || !str_prefix( argument, "black fury"))
         {
+            if (ch->pcdata->true_sex != 2)
+            {
+                send_to_char("You must be a true female to join the Black Furies.\n\r", ch);
+                return;
+            }
             send_to_char("Alright. You are now a Black Fury.\n\r",ch);
             ch->pcdata->tribe = BLACK_FURY;
             ch->clan = clan_lookup("blackfury");


### PR DESCRIPTION
Disallow non-female for black fury, and disallow non-lupus for red talon.