### PR TITLE
Change broken time math and adjust in-game year

### DIFF
--- a/db.c
+++ b/db.c
@@ -243,9 +243,7 @@ void boot_db()
     {
     long lhour, lday, lmonth;
 
-    // 896255250 corresponds to approximately 800 years ago, to the hour.
-    lhour       = (current_time)
-            / (PULSE_TICK / PULSE_PER_SECOND);
+    lhour       = current_time / (PULSE_TICK / PULSE_PER_SECOND);
     time_info.hour  = lhour  % 24;
     lday        = lhour  / 24;
     time_info.day   = lday   % 31;

--- a/db.c
+++ b/db.c
@@ -244,14 +244,14 @@ void boot_db()
     long lhour, lday, lmonth;
 
     // 896255250 corresponds to approximately 800 years ago, to the hour.
-    lhour       = (current_time - 896255250)
+    lhour       = (current_time)
             / (PULSE_TICK / PULSE_PER_SECOND);
     time_info.hour  = lhour  % 24;
     lday        = lhour  / 24;
     time_info.day   = lday   % 31;
     lmonth      = lday   / 31;
     time_info.month = lmonth % 12;
-    time_info.year  = lmonth / 12;
+    time_info.year  = number_range(1210, 1250);
     time_info.phase = number_range(0,7);
     time_info.moon_count = number_range(0,2);
 


### PR DESCRIPTION
Current time is based off of Unix time which is the number of seconds since some january in the 70s. Trying to get a date in the 1200s from that is nonsensical I have no idea how it worked to begin with. 

Chose a random date between 1210 and 1250 because why the heck not nobody pays attention to the year IC anyway it's 1200s-ish.