### PR TITLE
Hotfix 11.11.24   Binding Fix

### DIFF
--- a/ritual.c
+++ b/ritual.c
@@ -1303,6 +1303,7 @@ void do_bind(CHAR_DATA *ch, char *argument )
         }
         affect_to_obj(fetish,&af);
 
+        af.where     = TO_OBJECT;
         af.bitvector = ITEM_IS_ENHANCED;
         af.modifier = 0;
         af.location = 0;


### PR DESCRIPTION
Fixed error that applied bits incorrectly (didn't reset weapon to object in some cases)