### PR TITLE
Vibe-coded a social editor (close #193)

### DIFF
--- a/act_info.c
+++ b/act_info.c
@@ -743,14 +743,14 @@ void do_scroll(CHAR_DATA *ch, char *argument)
 void do_socials(CHAR_DATA *ch, char *argument)
 {
     char buf[MAX_STRING_LENGTH];
-    int iSocial;
+    struct social_type *social;
     int col;
 
     col = 0;
 
-    for (iSocial = 0; social_table[iSocial].name[0] != '\0'; iSocial++)
+    for (social = social_first; social != NULL; social = social->next)
     {
-    sprintf(buf,"%-12s",social_table[iSocial].name);
+    sprintf(buf,"%-12s",social->name);
     send_to_char(buf,ch);
     if (++col % 6 == 0)
         send_to_char("\n\r",ch);

--- a/act_wiz.c
+++ b/act_wiz.c
@@ -8712,6 +8712,7 @@ void do_copyover (CHAR_DATA *ch, char * argument)
     do_function( NULL, &do_asave, "helps");
     do_function( NULL, &do_asave, "commands");
     do_function( NULL, &do_asave, "quests");
+    do_function( NULL, &do_asave, "socials");
     write_to_descriptor (ch->desc->descriptor, "Proceeding to copyover...\n\r", 0);
 
     sprintf (buf, "\n\r\n\r *** Pull the Lever, Kronk! \n\r\n\r");

--- a/cmdtable.c
+++ b/cmdtable.c
@@ -689,6 +689,7 @@ const   struct  cmdfun_type cmdfun_table    [] =
     { "rpdump",     do_rpdump},
     { "rpstat",     do_rpstat},
     { "hedit",      do_hedit},
+    { "sedit",      do_sedit},
     { "cedit",      do_cedit},
     { "csave",      do_save_clans},
 

--- a/db2.c
+++ b/db2.c
@@ -45,7 +45,7 @@
 extern int flag_lookup args((const char *name, const struct flag_type *flag_table));
 
 /* values for db2.c */
-struct      social_type social_table        [MAX_SOCIALS];
+struct      social_type *social_first = NULL;
 int     social_count;
 
 /* snarf a socials file */
@@ -61,131 +61,165 @@ void load_socials( void )
 
     for ( ; ; )
     {
-        struct social_type social;
+        struct social_type *social;
         char *temp;
-        /* clear social */
-    social.char_no_arg = NULL;
-    social.others_no_arg = NULL;
-    social.char_found = NULL;
-    social.others_found = NULL;
-    social.vict_found = NULL;
-    social.char_not_found = NULL;
-    social.char_auto = NULL;
-    social.others_auto = NULL;
 
         temp = fread_word(fp);
         if (!strcmp(temp,"#0"))
-        return;  /* done */
+        {
+            fclose(fp);
+            return;  /* done */
+        }
 #if defined(social_debug)
     else
         fprintf(stderr,"%s\n\r",temp);
 #endif
 
-        strcpy(social.name,temp);
+        social = alloc_mem(sizeof(*social));
+        social->name = str_dup(temp);
         fread_to_eol(fp);
 
     temp = fread_string_eol(fp);
     if (!strcmp(temp,"$"))
-         social.char_no_arg = NULL;
+         social->char_no_arg = NULL;
     else if (!strcmp(temp,"#"))
     {
-         social_table[social_count] = social;
+         social->next = social_first;
+         social_first = social;
          social_count++;
          continue;
     }
         else
-        social.char_no_arg = temp;
+        social->char_no_arg = temp;
 
         temp = fread_string_eol(fp);
         if (!strcmp(temp,"$"))
-             social.others_no_arg = NULL;
+             social->others_no_arg = NULL;
         else if (!strcmp(temp,"#"))
         {
-         social_table[social_count] = social;
+         social->next = social_first;
+         social_first = social;
              social_count++;
              continue;
         }
         else
-        social.others_no_arg = temp;
+        social->others_no_arg = temp;
 
         temp = fread_string_eol(fp);
         if (!strcmp(temp,"$"))
-             social.char_found = NULL;
+             social->char_found = NULL;
         else if (!strcmp(temp,"#"))
         {
-         social_table[social_count] = social;
+         social->next = social_first;
+         social_first = social;
              social_count++;
              continue;
         }
         else
-        social.char_found = temp;
+        social->char_found = temp;
 
         temp = fread_string_eol(fp);
         if (!strcmp(temp,"$"))
-             social.others_found = NULL;
+             social->others_found = NULL;
         else if (!strcmp(temp,"#"))
         {
-         social_table[social_count] = social;
+         social->next = social_first;
+         social_first = social;
              social_count++;
              continue;
         }
         else
-        social.others_found = temp;
+        social->others_found = temp;
 
         temp = fread_string_eol(fp);
         if (!strcmp(temp,"$"))
-             social.vict_found = NULL;
+             social->vict_found = NULL;
         else if (!strcmp(temp,"#"))
         {
-         social_table[social_count] = social;
+         social->next = social_first;
+         social_first = social;
              social_count++;
              continue;
         }
         else
-        social.vict_found = temp;
+        social->vict_found = temp;
 
         temp = fread_string_eol(fp);
         if (!strcmp(temp,"$"))
-             social.char_not_found = NULL;
+             social->char_not_found = NULL;
         else if (!strcmp(temp,"#"))
         {
-         social_table[social_count] = social;
+         social->next = social_first;
+         social_first = social;
              social_count++;
              continue;
         }
         else
-        social.char_not_found = temp;
+        social->char_not_found = temp;
 
         temp = fread_string_eol(fp);
         if (!strcmp(temp,"$"))
-             social.char_auto = NULL;
+             social->char_auto = NULL;
         else if (!strcmp(temp,"#"))
         {
-         social_table[social_count] = social;
+         social->next = social_first;
+         social_first = social;
              social_count++;
              continue;
         }
         else
-        social.char_auto = temp;
+        social->char_auto = temp;
 
         temp = fread_string_eol(fp);
         if (!strcmp(temp,"$"))
-             social.others_auto = NULL;
+             social->others_auto = NULL;
         else if (!strcmp(temp,"#"))
         {
-             social_table[social_count] = social;
+             social->next = social_first;
+             social_first = social;
              social_count++;
              continue;
         }
         else
-        social.others_auto = temp;
+        social->others_auto = temp;
 
-    social_table[social_count] = social;
-        social_count++;
+    social->next = social_first;
+    social_first = social;
+    social_count++;
    }
 
-   fclose( fp );
-   return;
+}
+
+void save_socials()
+{
+    FILE *fp;
+    struct social_type *social;
+
+    if ( ( fp = fopen( SOCIAL_FILE, "w" ) ) == NULL )
+    {
+        perror( SOCIAL_FILE );
+        return;
+    }
+
+    for ( social = social_first; social != NULL; social = social->next )
+    {
+        if ( social->name == NULL || social->name[0] == '\0' )
+            continue;
+
+        fprintf( fp, "#%s\n", social->name );
+        fprintf( fp, "%s~\n", social->char_no_arg ? social->char_no_arg : "$" );
+        fprintf( fp, "%s~\n", social->others_no_arg ? social->others_no_arg : "$" );
+        fprintf( fp, "%s~\n", social->char_found ? social->char_found : "$" );
+        fprintf( fp, "%s~\n", social->others_found ? social->others_found : "$" );
+        fprintf( fp, "%s~\n", social->vict_found ? social->vict_found : "$" );
+        fprintf( fp, "%s~\n", social->char_not_found ? social->char_not_found : "$" );
+        fprintf( fp, "%s~\n", social->char_auto ? social->char_auto : "$" );
+        fprintf( fp, "%s~\n", social->others_auto ? social->others_auto : "$" );
+        fprintf( fp, "\n" );
+    }
+
+    fprintf( fp, "#0\n" );
+    fclose( fp );
 }
 
 

--- a/db2.c
+++ b/db2.c
@@ -70,124 +70,104 @@ void load_socials( void )
             fclose(fp);
             return;  /* done */
         }
-#if defined(social_debug)
-    else
-        fprintf(stderr,"%s\n\r",temp);
-#endif
 
         social = alloc_mem(sizeof(*social));
-        social->name = str_dup(temp);
+        /* Backwards compatibility: skip the # if it exists */
+        social->name = str_dup(temp[0] == '#' ? &temp[1] : temp);
         fread_to_eol(fp);
 
-    temp = fread_string_eol(fp);
-    if (!strcmp(temp,"$"))
-         social->char_no_arg = NULL;
-    else if (!strcmp(temp,"#"))
-    {
-         social->next = social_first;
-         social_first = social;
-         social_count++;
-         continue;
-    }
-        else
-        social->char_no_arg = temp;
-
-        temp = fread_string_eol(fp);
-        if (!strcmp(temp,"$"))
-             social->others_no_arg = NULL;
-        else if (!strcmp(temp,"#"))
-        {
-         social->next = social_first;
-         social_first = social;
-             social_count++;
-             continue;
-        }
-        else
-        social->others_no_arg = temp;
-
-        temp = fread_string_eol(fp);
-        if (!strcmp(temp,"$"))
-             social->char_found = NULL;
-        else if (!strcmp(temp,"#"))
-        {
-         social->next = social_first;
-         social_first = social;
-             social_count++;
-             continue;
-        }
-        else
-        social->char_found = temp;
-
-        temp = fread_string_eol(fp);
-        if (!strcmp(temp,"$"))
-             social->others_found = NULL;
-        else if (!strcmp(temp,"#"))
-        {
-         social->next = social_first;
-         social_first = social;
-             social_count++;
-             continue;
-        }
-        else
-        social->others_found = temp;
-
-        temp = fread_string_eol(fp);
-        if (!strcmp(temp,"$"))
-             social->vict_found = NULL;
-        else if (!strcmp(temp,"#"))
-        {
-         social->next = social_first;
-         social_first = social;
-             social_count++;
-             continue;
-        }
-        else
-        social->vict_found = temp;
-
-        temp = fread_string_eol(fp);
-        if (!strcmp(temp,"$"))
-             social->char_not_found = NULL;
-        else if (!strcmp(temp,"#"))
-        {
-         social->next = social_first;
-         social_first = social;
-             social_count++;
-             continue;
-        }
-        else
-        social->char_not_found = temp;
-
-        temp = fread_string_eol(fp);
-        if (!strcmp(temp,"$"))
-             social->char_auto = NULL;
-        else if (!strcmp(temp,"#"))
-        {
-         social->next = social_first;
-         social_first = social;
-             social_count++;
-             continue;
-        }
-        else
-        social->char_auto = temp;
-
-        temp = fread_string_eol(fp);
-        if (!strcmp(temp,"$"))
-             social->others_auto = NULL;
-        else if (!strcmp(temp,"#"))
+        social->char_no_arg = fread_string(fp);
+        if (social->char_no_arg[0] == '$' && social->char_no_arg[1] == '\0')
+             social->char_no_arg = NULL;
+        else if (social->char_no_arg[0] == '#' && social->char_no_arg[1] == '\0')
         {
              social->next = social_first;
              social_first = social;
              social_count++;
              continue;
         }
-        else
-        social->others_auto = temp;
 
-    social->next = social_first;
-    social_first = social;
-    social_count++;
+        social->others_no_arg = fread_string(fp);
+        if (social->others_no_arg[0] == '$' && social->others_no_arg[1] == '\0')
+             social->others_no_arg = NULL;
+        else if (social->others_no_arg[0] == '#' && social->others_no_arg[1] == '\0')
+        {
+             social->next = social_first;
+             social_first = social;
+             social_count++;
+             continue;
+        }
+
+        social->char_found = fread_string(fp);
+        if (social->char_found[0] == '$' && social->char_found[1] == '\0')
+             social->char_found = NULL;
+        else if (social->char_found[0] == '#' && social->char_found[1] == '\0')
+        {
+             social->next = social_first;
+             social_first = social;
+             social_count++;
+             continue;
+        }
+
+        social->others_found = fread_string(fp);
+        if (social->others_found[0] == '$' && social->others_found[1] == '\0')
+             social->others_found = NULL;
+        else if (social->others_found[0] == '#' && social->others_found[1] == '\0')
+        {
+             social->next = social_first;
+             social_first = social;
+             social_count++;
+             continue;
+        }
+
+        social->vict_found = fread_string(fp);
+        if (social->vict_found[0] == '$' && social->vict_found[1] == '\0')
+             social->vict_found = NULL;
+        else if (social->vict_found[0] == '#' && social->vict_found[1] == '\0')
+        {
+             social->next = social_first;
+             social_first = social;
+             social_count++;
+             continue;
+        }
+
+        social->char_not_found = fread_string(fp);
+        if (social->char_not_found[0] == '$' && social->char_not_found[1] == '\0')
+             social->char_not_found = NULL;
+        else if (social->char_not_found[0] == '#' && social->char_not_found[1] == '\0')
+        {
+             social->next = social_first;
+             social_first = social;
+             social_count++;
+             continue;
+        }
+
+        social->char_auto = fread_string(fp);
+        if (social->char_auto[0] == '$' && social->char_auto[1] == '\0')
+             social->char_auto = NULL;
+        else if (social->char_auto[0] == '#' && social->char_auto[1] == '\0')
+        {
+             social->next = social_first;
+             social_first = social;
+             social_count++;
+             continue;
+        }
+
+        social->others_auto = fread_string(fp);
+        if (social->others_auto[0] == '$' && social->others_auto[1] == '\0')
+             social->others_auto = NULL;
+        else if (social->others_auto[0] == '#' && social->others_auto[1] == '\0')
+        {
+             social->next = social_first;
+             social_first = social;
+             social_count++;
+             continue;
+        }
+
+        social->next = social_first;
+        social_first = social;
+        social_count++;
    }
-
 }
 
 void save_socials()

--- a/interp.c
+++ b/interp.c
@@ -410,14 +410,14 @@ bool check_social( CHAR_DATA *ch, char *command, char *argument )
 {
     char arg[MAX_INPUT_LENGTH];
     CHAR_DATA *victim;
-    int cmd;
+    struct social_type *social;
     bool found;
 
     found  = FALSE;
-    for ( cmd = 0; social_table[cmd].name[0] != '\0'; cmd++ )
+    for ( social = social_first; social != NULL; social = social->next )
     {
-    if ( command[0] == social_table[cmd].name[0]
-    &&   !str_prefix( command, social_table[cmd].name ) )
+    if ( command[0] == social->name[0]
+    &&   !str_prefix( command, social->name ) )
     {
         found = TRUE;
         break;
@@ -457,7 +457,7 @@ bool check_social( CHAR_DATA *ch, char *command, char *argument )
      * I just know this is the path to a 12" 'if' statement.  :(
      * But two players asked for it already!  -- Furey
      */
-    if ( !str_cmp( social_table[cmd].name, "snore" ) )
+    if ( !str_cmp( social->name, "snore" ) )
         break;
     send_to_char( "In your dreams, or what?\n\r", ch );
     return TRUE;
@@ -468,8 +468,8 @@ bool check_social( CHAR_DATA *ch, char *command, char *argument )
     victim = NULL;
     if ( arg[0] == '\0' )
     {
-    act( social_table[cmd].others_no_arg, ch, NULL, victim, TO_ROOM    );
-    act( social_table[cmd].char_no_arg,   ch, NULL, victim, TO_CHAR    );
+    act( social->others_no_arg, ch, NULL, victim, TO_ROOM    );
+    act( social->char_no_arg,   ch, NULL, victim, TO_CHAR    );
     }
     else if ( ( victim = get_char_room( ch, NULL, arg ) ) == NULL )
     {
@@ -477,14 +477,14 @@ bool check_social( CHAR_DATA *ch, char *command, char *argument )
     }
     else if ( victim == ch )
     {
-    act( social_table[cmd].others_auto,   ch, NULL, victim, TO_ROOM    );
-    act( social_table[cmd].char_auto,     ch, NULL, victim, TO_CHAR    );
+    act( social->others_auto,   ch, NULL, victim, TO_ROOM    );
+    act( social->char_auto,     ch, NULL, victim, TO_CHAR    );
     }
     else
     {
-    act( social_table[cmd].others_found,  ch, NULL, victim, TO_NOTVICT );
-    act( social_table[cmd].char_found,    ch, NULL, victim, TO_CHAR    );
-    act( social_table[cmd].vict_found,    ch, NULL, victim, TO_VICT    );
+    act( social->others_found,  ch, NULL, victim, TO_NOTVICT );
+    act( social->char_found,    ch, NULL, victim, TO_CHAR    );
+    act( social->vict_found,    ch, NULL, victim, TO_VICT    );
 
     if ( !IS_NPC(ch) && IS_NPC(victim)
     &&   !IS_AFFECTED(victim, AFF_CHARM)
@@ -497,11 +497,11 @@ bool check_social( CHAR_DATA *ch, char *command, char *argument )
 
         case 1: case 2: case 3: case 4:
         case 5: case 6: case 7: case 8:
-        act( social_table[cmd].others_found,
+        act( social->others_found,
             victim, NULL, ch, TO_NOTVICT );
-        act( social_table[cmd].char_found,
+        act( social->char_found,
             victim, NULL, ch, TO_CHAR    );
-        act( social_table[cmd].vict_found,
+        act( social->vict_found,
             victim, NULL, ch, TO_VICT    );
         break;
 

--- a/interp.h
+++ b/interp.h
@@ -390,6 +390,7 @@ DECLARE_DO_FUN( do_medit    );
 DECLARE_DO_FUN( do_oedit    );
 DECLARE_DO_FUN( do_mpedit   );
 DECLARE_DO_FUN( do_hedit    );
+DECLARE_DO_FUN( do_sedit    );
 DECLARE_DO_FUN( do_embrace  );
 DECLARE_DO_FUN( do_vampire  );
 DECLARE_DO_FUN( do_ghoul    );

--- a/merc.h
+++ b/merc.h
@@ -3357,7 +3357,7 @@ char    *PERS   args( (CHAR_DATA *ch, CHAR_DATA *looker, bool channel) );
  */
 struct  social_type
 {
-    char      name[20];
+    char *    name;
     char *    char_no_arg; // Shown to char, no argument.
     char *    others_no_arg; // Shown to room, no argument.
     char *    char_found; // Shown to char, target found.
@@ -3366,6 +3366,7 @@ struct  social_type
     char *    char_not_found; // Target not found
     char *      char_auto; // Show to char, (social) self
     char *      others_auto; // Show to room, (social) self
+    struct social_type *next;
 };
 
 
@@ -3393,7 +3394,7 @@ extern  const   struct  tool_type   tool_table  [];
 extern  const   struct  crafted_type    crafted_table   [];
 extern  const   struct  skill_type  skill_table [MAX_SKILL];
 extern  const   struct  group_type      group_table [MAX_GROUP];
-extern          struct social_type      social_table    [MAX_SOCIALS];
+extern          struct social_type      *social_first;
 
 
 

--- a/olc.c
+++ b/olc.c
@@ -62,6 +62,9 @@ bool run_olc_editor( DESCRIPTOR_DATA *d )
     case ED_HELP:
         hedit( d->character, d->incomm );
         break;
+    case ED_SOCIAL:
+        sedit( d->character, d->incomm );
+        break;
     case ED_COMMAND:
         cmdedit( d->character, d->incomm);
         break;
@@ -111,6 +114,9 @@ char *olc_ed_name( CHAR_DATA *ch )
     case ED_HELP:
         sprintf( buf, "HEdit" );
         break;
+    case ED_SOCIAL:
+        sprintf( buf, "SEdit" );
+        break;
    case ED_COMMAND:
     sprintf(buf, "CmdEdit" );
     break;
@@ -142,6 +148,7 @@ char *olc_ed_vnum( CHAR_DATA *ch )
     HELP_DATA *pHelp;
     CMD_DATA  *pCmd;
     QITEM_DATA *pItem;
+    struct social_type *pSocial;
     static char buf[MIL];
 
     buf[0] = '\0';
@@ -178,6 +185,10 @@ char *olc_ed_vnum( CHAR_DATA *ch )
     case ED_HELP:
         pHelp = (HELP_DATA *)ch->desc->pEdit;
         sprintf( buf, "%s", pHelp ? pHelp->keyword : "" );
+        break;
+    case ED_SOCIAL:
+        pSocial = (struct social_type *)ch->desc->pEdit;
+        sprintf( buf, "%s", pSocial ? pSocial->name : "" );
         break;
     case ED_CLAN:
         pClan = (CLAN_DATA *) ch->desc->pEdit;
@@ -266,6 +277,9 @@ bool show_commands( CHAR_DATA *ch, char *argument )
 	    break;
     case ED_HELP:
         show_olc_cmds( ch, hedit_table );
+        break;
+    case ED_SOCIAL:
+        show_olc_cmds( ch, sedit_table );
         break;
     case ED_COMMAND:
         show_olc_cmds( ch, cmdedit_table );
@@ -1965,6 +1979,110 @@ const struct olc_cmd_type hedit_table[] =
     {   "?",      show_help      },
 
     {   NULL, 0, }
+};
+
+/* Social Editor */
+void sedit( CHAR_DATA *ch, char *argument)
+{
+    char command[MIL];
+    char arg[MIL];
+    int cmd;
+
+    smash_tilde(argument);
+    strcpy(arg, argument);
+    argument = one_argument( argument, command);
+
+    if (ch->level < SUPREME)
+    {
+        send_to_char("SEdit: Insufficient security to modify socials.\n\r", ch);
+        edit_done(ch);
+        return;
+    }
+
+    if ( !str_cmp(command, "done") )
+    {
+        edit_done( ch );
+        return;
+    }
+
+    if ( command[0] == '\0' )
+    {
+        sedit_show( ch, argument );
+        return;
+    }
+
+    for ( cmd = 0; sedit_table[cmd].name != NULL; cmd++ )
+    {
+        if ( !str_prefix( command, sedit_table[cmd].name ) )
+        {
+            (*sedit_table[cmd].olc_fun) ( ch, argument );
+            return;
+        }
+    }
+
+    interpret( ch, arg );
+    return;
+}
+
+void do_sedit( CHAR_DATA *ch, char *argument )
+{
+    struct social_type *pSocial;
+    char arg1[MIL];
+    bool found = FALSE;
+
+    strcpy(arg1, argument);
+    if(argument[0] != '\0')
+    {
+        for ( pSocial = social_first; pSocial != NULL; pSocial = pSocial->next )
+        {
+            if ( is_name( arg1, pSocial->name ) )
+            {
+                ch->desc->pEdit = (void *)pSocial;
+                ch->desc->editor = ED_SOCIAL;
+                found = TRUE;
+                return;
+            }
+        }
+    }
+
+    if(!found)
+    {
+        argument = one_argument(arg1, arg1);
+
+        if(!str_cmp(arg1,"make"))
+        {
+            if (argument[0] == '\0')
+            {
+                send_to_char("Syntax: sedit make [social]\n\r",ch);
+                return;
+            }
+            if (sedit_make(ch, argument) )
+                ch->desc->editor = ED_SOCIAL;
+            return;
+        }
+    }
+
+    send_to_char( "SEdit:  There is no default social to edit.\n\r", ch );
+    return;
+}
+
+const struct olc_cmd_type sedit_table[] =
+{
+    { "commands", show_commands  },
+    { "show",     sedit_show     },
+    { "make",     sedit_make     },
+    { "delete",   sedit_delete   },
+    { "cnoarg",   sedit_cnoarg   },
+    { "onoarg",   sedit_onoarg   },
+    { "cfound",   sedit_cfound   },
+    { "ofound",   sedit_ofound   },
+    { "vfound",   sedit_vfound   },
+    { "cnotfound",sedit_cnotfound},
+    { "cauto",    sedit_cauto    },
+    { "oauto",    sedit_oauto    },
+    { "?",        show_help      },
+
+    { NULL, 0, }
 };
 /*Throw this in at the bottom of olc.c */
 

--- a/olc.h
+++ b/olc.h
@@ -72,6 +72,7 @@ void save_helps args( (void) );
 #define ED_QITEM    9
 #define ED_OPCODE   10
 #define ED_RPCODE   11
+#define ED_SOCIAL   12
 
 
 
@@ -90,6 +91,7 @@ void    cedit           args( ( CHAR_DATA *ch, char *argument ) );
 void    qiedit          args( ( CHAR_DATA *ch, char *argument ));
 void    opedit          args( ( CHAR_DATA *ch, char *argument ) );
 void    rpedit          args( ( CHAR_DATA *ch, char *argument ) );
+void    sedit           args( ( CHAR_DATA *ch, char *argument ) );
 
 
 /*
@@ -149,6 +151,7 @@ extern const struct olc_cmd_type        cedit_table[];
 extern const struct olc_cmd_type    qiedit_table[];
 extern const struct olc_cmd_type        opedit_table[];
 extern const struct olc_cmd_type        rpedit_table[];
+extern const struct olc_cmd_type        sedit_table[];
 
 
 
@@ -167,6 +170,7 @@ DECLARE_DO_FUN( do_cmdedit  );
 DECLARE_DO_FUN( do_qiedit   );
 DECLARE_DO_FUN( do_opedit       );
 DECLARE_DO_FUN( do_rpedit       );
+DECLARE_DO_FUN( do_sedit        );
 
 /*
  * General Functions
@@ -326,6 +330,19 @@ DECLARE_OLC_FUN( hedit_level   );
 DECLARE_OLC_FUN( hedit_keywords   );
 DECLARE_OLC_FUN( hedit_delete );
 
+/* Social Editor */
+DECLARE_OLC_FUN( sedit_show );
+DECLARE_OLC_FUN( sedit_make );
+DECLARE_OLC_FUN( sedit_delete );
+DECLARE_OLC_FUN( sedit_cnoarg );
+DECLARE_OLC_FUN( sedit_onoarg );
+DECLARE_OLC_FUN( sedit_cfound );
+DECLARE_OLC_FUN( sedit_ofound );
+DECLARE_OLC_FUN( sedit_vfound );
+DECLARE_OLC_FUN( sedit_cnotfound );
+DECLARE_OLC_FUN( sedit_cauto );
+DECLARE_OLC_FUN( sedit_oauto );
+
 
 //Cmdedit functions
 DECLARE_OLC_FUN( cmdedit_show       );
@@ -395,6 +412,7 @@ DECLARE_OLC_FUN( rpedit_list		);
 #define EDIT_QITEM( Ch, Item ) (Item = (QITEM_DATA *) Ch->desc->pEdit )
 #define EDIT_OPCODE(Ch, Code)   ( Code = (PROG_CODE*)Ch->desc->pEdit )
 #define EDIT_RPCODE(Ch, Code)   ( Code = (PROG_CODE*)Ch->desc->pEdit )
+#define EDIT_SOCIAL(Ch, Social) ( Social = (struct social_type *)Ch->desc->pEdit )
 
 
 /*

--- a/olc_act.c
+++ b/olc_act.c
@@ -6893,6 +6893,13 @@ bool sedit_show( CHAR_DATA *ch, char *argument )
 
     EDIT_SOCIAL(ch, soc);
 
+    send_to_char("Substitution codes:\n\r", ch);
+    send_to_char("$n: actor name       $N: victim name\n\r", ch);
+    send_to_char("$e: actor he/she     $E: victim he/she\n\r", ch);
+    send_to_char("$m: actor him/her    $M: victim him/her\n\r", ch);
+    send_to_char("$s: actor his/her    $S: victim his/her\n\r", ch);
+    send_to_char("--------------------------------------------------\n\r", ch);
+
     sprintf(buf, "Name:        [%s]\n\r", soc->name);
     send_to_char(buf, ch);
     sprintf(buf, "cnoarg:      [%s]\n\r", soc->char_no_arg ? soc->char_no_arg : "(none)");
@@ -6988,7 +6995,7 @@ bool sedit_delete( CHAR_DATA *ch, char *argument )
     free_mem(soc, sizeof(*soc));
 
     social_count--;
-    
+
     send_to_char("Social deleted.\n\r", ch);
     edit_done(ch);
     return TRUE;

--- a/olc_act.c
+++ b/olc_act.c
@@ -6878,3 +6878,151 @@ REDIT ( redit_delrprog )
     send_to_char("Rprog removed.\n\r", ch);
     return TRUE;
 }
+
+
+/* ========================================================================= */
+/*                              SOCIAL EDITOR                                */
+/* ========================================================================= */
+
+extern int social_count;
+
+bool sedit_show( CHAR_DATA *ch, char *argument )
+{
+    struct social_type *soc;
+    char buf[MAX_STRING_LENGTH];
+
+    EDIT_SOCIAL(ch, soc);
+
+    sprintf(buf, "Name:        [%s]\n\r", soc->name);
+    send_to_char(buf, ch);
+    sprintf(buf, "cnoarg:      [%s]\n\r", soc->char_no_arg ? soc->char_no_arg : "(none)");
+    send_to_char(buf, ch);
+    sprintf(buf, "onoarg:      [%s]\n\r", soc->others_no_arg ? soc->others_no_arg : "(none)");
+    send_to_char(buf, ch);
+    sprintf(buf, "cfound:      [%s]\n\r", soc->char_found ? soc->char_found : "(none)");
+    send_to_char(buf, ch);
+    sprintf(buf, "ofound:      [%s]\n\r", soc->others_found ? soc->others_found : "(none)");
+    send_to_char(buf, ch);
+    sprintf(buf, "vfound:      [%s]\n\r", soc->vict_found ? soc->vict_found : "(none)");
+    send_to_char(buf, ch);
+    sprintf(buf, "cnotfound:   [%s]\n\r", soc->char_not_found ? soc->char_not_found : "(none)");
+    send_to_char(buf, ch);
+    sprintf(buf, "cauto:       [%s]\n\r", soc->char_auto ? soc->char_auto : "(none)");
+    send_to_char(buf, ch);
+    sprintf(buf, "oauto:       [%s]\n\r", soc->others_auto ? soc->others_auto : "(none)");
+    send_to_char(buf, ch);
+
+    return FALSE;
+}
+
+bool sedit_make( CHAR_DATA *ch, char *argument )
+{
+    struct social_type *soc;
+    char arg[MAX_STRING_LENGTH];
+
+    one_argument(argument, arg);
+
+    if ( arg[0] == '\0' )
+    {
+        send_to_char("Syntax: sedit make [social]\n\r", ch);
+        return FALSE;
+    }
+
+    for ( soc = social_first; soc != NULL; soc = soc->next )
+    {
+        if ( !str_cmp(arg, soc->name) )
+        {
+            send_to_char("A social with that name already exists.\n\r", ch);
+            return FALSE;
+        }
+    }
+
+    soc = alloc_mem(sizeof(*soc));
+    soc->name = str_dup(arg);
+    soc->char_no_arg = NULL;
+    soc->others_no_arg = NULL;
+    soc->char_found = NULL;
+    soc->others_found = NULL;
+    soc->vict_found = NULL;
+    soc->char_not_found = NULL;
+    soc->char_auto = NULL;
+    soc->others_auto = NULL;
+
+    soc->next = social_first;
+    social_first = soc;
+    social_count++;
+
+    ch->desc->pEdit = (void *)soc;
+    send_to_char("Social created.\n\r", ch);
+    return TRUE;
+}
+
+bool sedit_delete( CHAR_DATA *ch, char *argument )
+{
+    struct social_type *soc;
+    struct social_type *prev = NULL;
+
+    EDIT_SOCIAL(ch, soc);
+
+    for ( struct social_type *s = social_first; s != NULL; s = s->next )
+    {
+        if ( s == soc )
+            break;
+        prev = s;
+    }
+
+    if ( prev == NULL )
+        social_first = soc->next;
+    else
+        prev->next = soc->next;
+
+    free_string(soc->name);
+    free_string(soc->char_no_arg);
+    free_string(soc->others_no_arg);
+    free_string(soc->char_found);
+    free_string(soc->others_found);
+    free_string(soc->vict_found);
+    free_string(soc->char_not_found);
+    free_string(soc->char_auto);
+    free_string(soc->others_auto);
+    free_mem(soc, sizeof(*soc));
+
+    social_count--;
+    
+    send_to_char("Social deleted.\n\r", ch);
+    edit_done(ch);
+    return TRUE;
+}
+
+#define SEDIT_STR( func, field ) \
+bool sedit_##func( CHAR_DATA *ch, char *argument ) \
+{ \
+    struct social_type *soc; \
+    EDIT_SOCIAL(ch, soc); \
+    if ( argument[0] == '\0' ) \
+    { \
+        send_to_char("Syntax: " #func " [string]\n\r", ch); \
+        send_to_char("        " #func " none\n\r", ch); \
+        return FALSE; \
+    } \
+    if ( !str_cmp(argument, "none") ) \
+    { \
+        free_string(soc->field); \
+        soc->field = NULL; \
+        send_to_char(#field " cleared.\n\r", ch); \
+        return TRUE; \
+    } \
+    free_string(soc->field); \
+    soc->field = str_dup(argument); \
+    send_to_char(#field " set.\n\r", ch); \
+    return TRUE; \
+}
+
+SEDIT_STR(cnoarg, char_no_arg)
+SEDIT_STR(onoarg, others_no_arg)
+SEDIT_STR(cfound, char_found)
+SEDIT_STR(ofound, others_found)
+SEDIT_STR(vfound, vict_found)
+SEDIT_STR(cnotfound, char_not_found)
+SEDIT_STR(cauto, char_auto)
+SEDIT_STR(oauto, others_auto)

--- a/olc_save.c
+++ b/olc_save.c
@@ -1251,6 +1251,7 @@ void do_asave( CHAR_DATA *ch, char *argument )
         send_to_char( "  asave commands - saves the command table\n\r", ch);
         send_to_char( "  asave config   - saves configuration file\n\r", ch);
         send_to_char( "  asave quests   - saves quest item table\n\r", ch);
+        send_to_char( "  asave socials  - saves socials\n\r", ch);
         send_to_char( "\n\r", ch );
     }
 
@@ -1416,6 +1417,16 @@ void do_asave( CHAR_DATA *ch, char *argument )
             sendch("QItem Table Saved.\n\r", ch);
         else
             log_string("Autosave: Quests");
+        return;
+    }
+    if (!str_prefix( arg1, "socials") )
+    {
+        extern void save_socials(void);
+        save_socials();
+        if (ch)
+            sendch("Socials Saved.\n\r", ch);
+        else
+            log_string("Autosave: Socials");
         return;
     }
     /* Save area being edited, if authorized. */


### PR DESCRIPTION
# Goal

Implement a Social Editor (`sedit`) using the OLC framework. It will use `hedit` as a guide and allow building/editing socials in-game, automatically saving them to the `social.dat` file. Furthermore, we will migrate `social_table` from a static array to a dynamic linked list.

## User Review Required

> [!WARNING]
> Migrating `social_table` to a linked list means changing the fundamental structure of `struct social_type` and rewriting iteration logic in multiple files (`interp.c`, `act_info.c`, `db2.c`). These changes touch central command-parsing logic.

## Open Questions

> [!NOTE]
> None at this time. Using `ch->level < SUPREME` (which is `MAX_LEVEL - 1`) as the security requirement for `do_sedit` as approved.

## Proposed Changes

### `merc.h`

#### [MODIFY] [merc.h](file:///c:/haven-support/src/merc.h)
- Add `struct social_type *next;` to `struct social_type`.
- Remove `extern struct social_type social_table[MAX_SOCIALS];`
- Add `extern struct social_type *social_first;`
- Change `char name[20]` to `char *name;` or keep it `char name[20];`. Since OLC needs to allocate and free structures, it's fine to keep `name[20]` as long as we strncpy it, or change it to `char *name` and `str_dup` it. We will change it to `char *name;` to be safe and consistent with strings.

### `db2.c` / `db.h`

#### [MODIFY] [db2.c](file:///c:/haven-support/src/db2.c)
- Remove `social_table[MAX_SOCIALS]` array definition.
- Add `struct social_type *social_first;` definition.
- Modify `load_socials()` to allocate memory dynamically for each social and link them into the `social_first` list instead of inserting them into the static array.
- Add the `save_socials()` function to iterate over `social_first` and write the data back to `SOCIAL_FILE` in the same syntax used by `load_socials()`.

### `interp.c`

#### [MODIFY] [interp.c](file:///c:/haven-support/src/interp.c)
- Modify `check_social()` to iterate through the `social_first` linked list instead of checking against `social_table[cmd]`.

### `act_info.c`

#### [MODIFY] [act_info.c](file:///c:/haven-support/src/act_info.c)
- Modify `do_socials()` to iterate over the `social_first` linked list instead of `social_table`.

### `olc.h`

#### [MODIFY] [olc.h](file:///c:/haven-support/src/olc.h)
- Define `ED_SOCIAL` as `10` (or the next available number).
- Add prototypes for `sedit`, `do_sedit`, and `sedit_table`.
- Add `DECLARE_OLC_FUN` prototypes for `sedit_show`, `sedit_make`, `sedit_delete`, `sedit_cnoarg`, `sedit_onoarg`, `sedit_cfound`, `sedit_ofound`, `sedit_vfound`, `sedit_cauto`, `sedit_oauto`, and `sedit_cnotfound`.

### `olc.c`

#### [MODIFY] [olc.c](file:///c:/haven-support/src/olc.c)
- In the main `olc` command dispatcher, add a case for `ED_SOCIAL` to direct input to the `sedit` parser.
- Define `do_sedit(CHAR_DATA *ch, char *argument)` to let users enter the `sedit` interpreter and assign the social they are editing to their `ch->desc->pEdit`.
- Define `sedit(CHAR_DATA *ch, char *argument)` to dispatch commands based on `sedit_table`.
- Define `sedit_table` containing all specific `sedit_*` commands.

### `olc_act.c`

#### [MODIFY] [olc_act.c](file:///c:/haven-support/src/olc_act.c)
- Define `sedit_make` to dynamically allocate a new `social_type`, add it to the `social_first` linked list, and increment `social_count`.
- Define `sedit_show` to print the strings of the social being edited.
- Define `sedit_delete` to remove the social from `social_first`, free its allocated memory, and decrement `social_count`.
- Define the remaining `sedit_*` commands (`cnoarg`, `onoarg`, `cfound`, `ofound`, `vfound`, `cnotfound`, `cauto`, `oauto`) to update the individual string fields of the social.

### `olc_save.c`

#### [MODIFY] [olc_save.c](file:///c:/haven-support/src/olc_save.c)
- Update `do_asave` to accept `asave socials` which will explicitly call `save_socials()`.

### `interp.h` / `cmdtable.c`

#### [MODIFY] [interp.h](file:///c:/haven-support/src/interp.h)
- Add `DECLARE_DO_FUN( do_sedit );`

#### [MODIFY] [cmdtable.c](file:///c:/haven-support/src/cmdtable.c)
- Add `sedit` entry to the `cmd_table` with `SUPREME` level access.

## Verification Plan

### Manual Verification
- Recompile the game.
- Start the server and login as an Implementor.
- Test `socials` to ensure the list displays correctly via the linked list.
- Use a social to ensure the `check_social` linked list traversal works.
- Test `sedit make test_social` to see if a social is made.
- Set the various strings using `cnoarg`, `ofound`, etc.
- Try `test_social` to ensure it works.
- Test `asave socials` and verify `social.dat` updates properly.
- Test `sedit delete test_social` and `asave socials` to ensure memory clearing and saving works smoothly.
