### PR TITLE
Moved success message before descriptor change in possession

### DIFF
--- a/disciplines.c
+++ b/disciplines.c
@@ -3931,6 +3931,8 @@ void do_possession( CHAR_DATA *ch, char *argument )
     }
     sprintf(buf,"$N switches into %s using Possession.",victim->short_descr);
     wiznet(buf,ch,NULL,WIZ_SWITCHES,WIZ_SECURE,get_trust(ch));
+    act("You possess the mind of $N!",ch,NULL,victim,TO_CHAR);
+    send_to_char("Type 'return' to return to your own body.\n\r", ch);
 
     ch->desc->character = victim;
     ch->desc->original  = ch;
@@ -3941,7 +3943,6 @@ void do_possession( CHAR_DATA *ch, char *argument )
         victim->prompt = str_dup(ch->prompt);
     victim->comm = ch->comm;
     victim->lines = ch->lines;
-    act("You possess the mind of $N!",ch,NULL,victim,TO_VICT);
     return;
 }
 


### PR DESCRIPTION
I didnt think there -was-a message on success but the problem was the message was being sent -after- changing descriptors so ch never saw the message.

Also added a message describing how to return to your body for people that cant read helpfiles.