### PR TITLE
Removed some log messages we dont need logged (closes #408)

### DIFF
--- a/comm.c
+++ b/comm.c
@@ -1066,8 +1066,8 @@ void init_descriptor( int control )
         ( addr >> 24 ) & 0xFF, ( addr >> 16 ) & 0xFF,
         ( addr >>  8 ) & 0xFF, ( addr       ) & 0xFF
         );
-    sprintf( log_buf, "Sock.sinaddr:  %s", buf );
-    log_string( log_buf );
+    // sprintf( log_buf, "Sock.sinaddr:  %s", buf );
+    // log_string( log_buf );
     if (!resolver)
     {from = NULL;}
     else
@@ -1254,14 +1254,15 @@ bool read_from_descriptor( DESCRIPTOR_DATA *d )
     }
     else if ( nRead == 0 )
     {
-        log_string( "EOF encountered on read." );
+        // log_string( "EOF encountered on read." );
         return FALSE;
     }
     else if ( errno == EWOULDBLOCK )
         break;
     else
     {
-        perror( "Read_from_descriptor" );
+        if (errno != ECONNRESET)
+            perror( "Read_from_descriptor" );
         return FALSE;
     }
     }


### PR DESCRIPTION
1. Removed Sock.sinaddr:
Commented out the sprintf and log_string calls in init_descriptor() that printed the IP address of every incoming connection. IDGAF about every IP the internet is much bigger than it was in 1995.

2. Removed EOF encountered on read.
Commented out the log_string() call inside read_from_descriptor() that was blindly alerting whenever a read operation returned 0 bytes (a normal occurrence when a client disconnects cleanly or a crawler closes the socket after polling). 

3. Filtered Connection reset by peer
Added a conditional filter around the perror("Read_from_descriptor"); call inside read_from_descriptor(). It now specifically checks if (errno != ECONNRESET) before logging the error. This safely ignores the "Connection reset by peer" errors generated when clients (or crawlers) drop their connections ungracefully, while still ensuring other potentially critical socket errors are logged. 