### PR TITLE
Moved all manipulation of ch->qpoints into gain_qp (closes #281)

### DIFF
--- a/act_move.c
+++ b/act_move.c
@@ -2359,7 +2359,7 @@ void do_hometown (CHAR_DATA *ch, char *argument)
 
     if (!str_cmp(arg2, "confirm"))
     {
-        ch->qpoints -= 200;
+        gain_qp(ch, -200);
         sendch(" +-----------------------------------------------+\n\r", ch);
         cprintf(ch, " +    Setting new hometown to:   {y%10s{x      +\n\r +    {Y250QP{x deducted.    {g%6dQP{x remaining.     +\n\r", hometown_table[hn].name, ch->qpoints);
         sendch(" +-----------------------------------------------+\n\r", ch);

--- a/act_wiz.c
+++ b/act_wiz.c
@@ -9922,7 +9922,6 @@ void do_qpoint(CHAR_DATA *ch, char *argument)
 
     if(points > 0)
     {
-        victim->totalqpoints += points;
         sprintf(buf, "You have been rewarded {Y%d {xquest points!\n\r", points);
         send_to_char(buf,victim);
     }
@@ -9932,7 +9931,7 @@ void do_qpoint(CHAR_DATA *ch, char *argument)
         send_to_char(buf,victim);
     }
 
-    victim->qpoints += points;
+    gain_qp(victim, points);
     sprintf(buf, "{W%s {xnow has {Y%d {xquest points.\n\r", victim->name, victim->qpoints);
     send_to_char(buf,ch);
     sprintf(buf, "You now have {Y%d {xquest points.\n\r", victim->qpoints);

--- a/fight.c
+++ b/fight.c
@@ -3540,10 +3540,7 @@ void group_gain( CHAR_DATA *ch, CHAR_DATA *victim )
         }
         send_to_char( buf, gch );
         gain_exp( gch, xp );
-        gch->qpoints += qp;
-        gch->totalqpoints += qp;
-        if (gch->qpoints > MAX_QPOINTS)
-            gch->qpoints = MAX_QPOINTS;
+        gain_qp(gch, qp);
 
         if (IS_SET(ch->act2, PLR2_QUESTOR)&&IS_NPC(victim))
         {
@@ -3577,10 +3574,7 @@ void group_gain( CHAR_DATA *ch, CHAR_DATA *victim )
                 else
                 {
                     qp = number_range(1,5);
-                    gch->qpoints += qp;
-                    gch->totalqpoints += qp;
-                    if (gch->qpoints > MAX_QPOINTS)
-                        gch->qpoints = MAX_QPOINTS;
+                    gain_qp(gch, qp);
                     sprintf(buf, "{MTREAT!:  {GMystic energy fills you, as you gain %d quest points.{x\n\r", qp);
                     send_to_char(buf, gch);
                 }

--- a/mob_cmds.c
+++ b/mob_cmds.c
@@ -3362,8 +3362,7 @@ void do_mpqpoint(CHAR_DATA *ch, char *argument)
         send_to_char(buf,victim);
     }
 
-    victim->qpoints += points;
-		victim->totalqpoints += points;
+    gain_qp(victim, points);
     sprintf(log_buf, "%s was awarded %d Qpoints by mob %d (Now has %d)",victim->name, points, IS_NPC(ch) ? ch->pIndexData->vnum : 0, victim->qpoints);
     wiznet(log_buf,ch,NULL,WIZ_SECURE,0,0);
     log_string(log_buf);

--- a/quest.c
+++ b/quest.c
@@ -831,7 +831,7 @@ const struct reward_type reward_table[]=
     {
     ch->level += 1;
     advance_level( ch,TRUE);
-    ch->qpoints -= 100;
+    gain_qp(ch, -100);
     }
     sprintf(buf, "You spend %d quest points and purchase yourself to level %d!\n\r", atoi(arg2)*100, ch->level);
     send_to_char(buf, ch);
@@ -878,7 +878,7 @@ const struct reward_type reward_table[]=
     {
     victim->level += 1;
     advance_level( victim,TRUE);
-    ch->qpoints -= 100;
+    gain_qp(ch, -100);
     }
     sprintf(buf, "You spend %d quest points and purchase %s to level %d!\n\r", atoi(arg3)*100, victim->name, victim->level);
     send_to_char(buf, ch);
@@ -926,7 +926,7 @@ const struct reward_type reward_table[]=
     { found = TRUE;
         if (ch->qpoints >= reward_table[i].cost)
         {
-        ch->qpoints -= reward_table[i].cost;
+        gain_qp(ch, -reward_table[i].cost);
         if(reward_table[i].object)
                 obj = create_object(get_obj_index(reward_table[i].value),ch->level);
         else
@@ -1046,7 +1046,7 @@ const struct reward_type reward_table[]=
         ch->questobj = 0;
             ch->nextquest = 10;
         ch->gold += reward;
-        ch->qpoints += pointreward;
+        gain_qp(ch, pointreward);
         ch->quest_accum += pointreward;
         if(obj_found) extract_obj(obj);
      return;

--- a/update.c
+++ b/update.c
@@ -153,7 +153,8 @@ void gain_qp( CHAR_DATA *ch, int gain )
         return;
 
     ch->qpoints += gain;
-    ch->totalqpoints += gain;
+    if (gain > 0)
+        ch->totalqpoints += gain;
     
     if (ch->qpoints > MAX_QPOINTS)
     {
@@ -162,6 +163,10 @@ void gain_qp( CHAR_DATA *ch, int gain )
         send_to_char(buf, ch);
 
         ch->qpoints = MAX_QPOINTS;
+    }
+    else if (ch->qpoints < 0)
+    {
+        ch->qpoints = 0;
     }
 
     return;
@@ -895,7 +900,7 @@ void char_update( void )
                 REMOVE_BIT(ch->act,PLR_IC);
                 send_to_char("You are no longer {D({CIC{D){x!  Quit trying to break the buffer!\n\r",ch);
                 wiznet("{D$N has voided while {W({CIC{W){D!{x",ch,NULL,WIZ_LINKS,0,0);
-                ch->qpoints -= 10;
+                gain_qp(ch, -10);
                 send_to_char("You have just lost {R10{x quest points! This is a warning!\n\r",ch);
                 send_to_char("Chronic voiding while IC will be met with further warnings and\n\r", ch);
                 send_to_char("potential flagging for being excluded from the IC qp gain system.\n\r", ch);
@@ -1016,8 +1021,7 @@ void char_update( void )
         if (!ch) // Guard against null ch being returned from chimaera wearing off.
             continue;
 
-if (ch->qpoints > MAX_QPOINTS)
-    ch->qpoints = MAX_QPOINTS;
+
 
     if(!IS_NPC(ch) && ch->in_room != NULL && !IS_IMMORTAL(ch) && ch->in_room->sector_type == SECT_WATER_DROWN && (ch->race != race_lookup("vampire") ||
     ch->race != race_lookup("methuselah")))
@@ -1159,8 +1163,7 @@ if (ch->qpoints > MAX_QPOINTS)
 
         // Line for this into gxp as well
              global_xp += qpaward*xpmult;
-             ch->qpoints += qpaward;
-             ch->totalqpoints += qpaward;
+             gain_qp(ch, qpaward);
         }
 
 /*
@@ -1179,8 +1182,7 @@ if (ch->qpoints > MAX_QPOINTS)
        }
 */
 
-       if (ch->qpoints > MAX_QPOINTS)
-           ch->qpoints = MAX_QPOINTS;
+
         }
 
 


### PR DESCRIPTION
Changes Made

- Modified gain_qp() in update.c to safely clamp qpoints to 0 when receiving a negative gain value. This prevents negative QPs across the entire MUD system, including fixing the undocumented edgecase in Limbo voiding where a player's qpoints could inadvertently go negative.
- Added logic inside gain_qp() to prevent totalqpoints from decreasing when spending QPs by only incrementing when gain > 0.
- Scanned the codebase and replaced 16 direct manipulations of ->qpoints with calls to gain_qp().
- Removed redundant MAX_QPOINTS limit bounds-checking code near the replaced snippets, as gain_qp() already caps points dynamically.
- Verified successful compilation via WSL make.