### PR TITLE
Increased buffer size and added diagnostic info

### DIFF
--- a/recycle.c
+++ b/recycle.c
@@ -532,7 +532,7 @@ void free_mem_data(MEM_DATA *memory)
 /* buffer sizes */
 const int buf_size[MAX_BUF_LIST] =
 {
-    16,32,64,128,256,1024,2048,4096,8192,16384
+    16,32,64,128,256,1024,2048,4096,8192,16384,32768,65536,131072
 };
 
 /* local procedure for finding the next acceptable size */
@@ -637,9 +637,14 @@ bool add_buf(BUFFER *buffer, char *string)
     {
         if (buffer->size == -1) /* overflow */
         {
+        char buf[MAX_STRING_LENGTH];
         buffer->size = oldsize;
         buffer->state = BUFFER_OVERFLOW;
         bug("buffer overflow past size %d",buffer->size);
+        sprintf(buf, "Context: %.100s", buffer->string);
+        log_string(buf);
+        sprintf(buf, "Appending: %.100s", string);
+        log_string(buf);
         return FALSE;
         }
     }

--- a/recycle.h
+++ b/recycle.h
@@ -31,8 +31,8 @@ extern int mobile_count;
 
 /* stuff for providing a crash-proof buffer */
 
-#define MAX_BUF		16384
-#define MAX_BUF_LIST 	10
+#define MAX_BUF		131072
+#define MAX_BUF_LIST 	13
 #define BASE_BUF 	1024
 
 /* valid states */


### PR DESCRIPTION
### Increased Buffer Capacity
In [recycle.h](file:///c:/haven-support/src/recycle.h) and [recycle.c](file:///c:/haven-support/src/recycle.c), I have increased the maximum buffer size from 16KB to 128KB. This should significantly reduce the frequency of "buffer overflow past size 16384" errors.

- `MAX_BUF` is now `131072`.
- `MAX_BUF_LIST` is now `13`.
- `buf_size` array now includes `32768, 65536, 131072`.

### Diagnostic Logging
In [recycle.c](file:///c:/haven-support/src/recycle.c), I modified the `add_buf` function. If a buffer overflow is detected, the MUD will now log:
1. The existing overflow message.
2. The first 100 characters of the current buffer content (`Context`).
3. The first 100 characters of the string that was being added (`Appending`).

This will allow us to see exactly what data is causing the overflow in the logs.