### PR TITLE
Implementation of gmcp and ansi truecolor

### DIFF
--- a/act_comm.c
+++ b/act_comm.c
@@ -2657,10 +2657,53 @@ void do_colour( CHAR_DATA *ch, char *argument )
     }
     return;
     }
+    else if ( !str_cmp( arg, "256" ) || !str_cmp( arg, "ansi256" ) )
+    {
+        if ( !IS_SET( ch->act, PLR_COLOUR ) )
+        {
+            send_to_char( "You must have standard colour enabled first.\n\r", ch );
+            return;
+        }
+        if ( !IS_SET( ch->act2, PLR2_ANSI256 ) )
+        {
+            SET_BIT( ch->act2, PLR2_ANSI256 );
+            send_to_char( "Extended 256-color support is now {vON{x!\n\r", ch );
+        }
+        else
+        {
+            REMOVE_BIT( ch->act2, PLR2_ANSI256 );
+            send_to_char( "Extended 256-color support is now OFF (falling back to standard ANSI).\n\r", ch );
+        }
+        return;
+    }
+    else if ( !str_cmp( arg, "palette" ) || !str_cmp( arg, "list" ) || !str_cmp( arg, "chart" ) )
+    {
+        send_to_char( "{D-===========================================================================-{x\n\r", ch );
+        send_to_char( "                         {WExtended Color Palette Chart{x\n\r", ch );
+        send_to_char( "{D-===========================================================================-{x\n\r", ch );
+        send_to_char( "  {{r{r dark red{x      {{g{g dark green{x    {{b{b dark blue{x     {{c{c dark cyan{x\n\r", ch );
+        send_to_char( "  {{m{m dark magenta{x  {{y{y dark yellow{x   {{w{w gray/white{x    {{D{D dark gray{x\n\r", ch );
+        send_to_char( "  {{R{R bright red{x    {{G{G bright green{x  {{B{B cornflower{x    {{C{C bright cyan{x\n\r", ch );
+        send_to_char( "  {{M{M bright mag{x    {{Y{Y bright yel{x    {{W{W bright white{x\n\r", ch );
+        send_to_char( "{D- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -{x\n\r", ch );
+        send_to_char( "  {{v{v violet{x        {{V{V br violet{x     {{P{P hot pink{x      {{p{p peach{x\n\r", ch );
+        send_to_char( "  {{o{o orange{x        {{O{O br orange{x     {{l{l lime green{x    {{L{L light green{x\n\r", ch );
+        send_to_char( "  {{t{t teal{x          {{T{T turquoise{x     {{a{a azure{x         {{A{A sky blue{x\n\r", ch );
+        send_to_char( "  {{n{n navy{x          {{N{N midnight{x      {{e{e emerald{x       {{E{E br emerald{x\n\r", ch );
+        send_to_char( "  {{f{f forest gr{x     {{F{F fern green{x    {{s{s silver{x        {{S{S steel gray{x\n\r", ch );
+        send_to_char( "  {{I{I indigo{x        {{i{i ice blue{x      {{j{j jade{x          {{J{J bright jade{x\n\r", ch );
+        send_to_char( "  {{k{k khaki{x         {{K{K gold{x          {{u{u rust{x          {{U{U umber{x\n\r", ch );
+        send_to_char( "  {{q{q quartz{x        {{Q{Q cream{x         {{h{h honey gold{x    {{H{H lavender{x\n\r", ch );
+        send_to_char( "  {{d{d dusty rose{x    {{z{z crimson{x       {{Z{Z scarlet{x\n\r", ch );
+        send_to_char( "{D-===========================================================================-{x\n\r", ch );
+        send_to_char( "  Usage: {gcolour 256{x to toggle 256-color support manually.\n\r", ch );
+        return;
+    }
     else
     {
-    send_to_char_bw( "Colour Configuration is unavailable in this\n\r", ch );
-    send_to_char_bw( "version of colour, sorry\n\r", ch );
+        send_to_char( "Syntax: colour\n\r", ch );
+        send_to_char( "        colour 256\n\r", ch );
+        send_to_char( "        colour palette\n\r", ch );
     }
 
     return;

--- a/comm.c
+++ b/comm.c
@@ -367,7 +367,7 @@ bool    write_to_descriptor args( ( int desc, char *txt, int length ) );
 
 
 
-char randomcolors[MAX_RANDOM+2] = "RrGgYyBbMmCcWwD";
+char randomcolors[MAX_RANDOM+2] = "RrGgYyBbMmCcWwDvVPpoOlLtTaAnNeEfFsSiIjJkKuUqQhHdzZ";
 
 /*
  * Other local functions (OS-independent).
@@ -1107,7 +1107,10 @@ void init_descriptor( int control )
     {
     extern char * help_greeting;
     const char mssp_will[] = { IAC, WILL, TELOPT_MSSP, '\0' };
+    const char gmcp_will[] = { IAC, WILL, TELOPT_GMCP, '\0' };
     write_to_buffer( dnew, mssp_will, 0 );
+    write_to_buffer( dnew, gmcp_will, 0 );
+
 
     if ( help_greeting[0] == '.' )
         write_to_buffer( dnew, help_greeting+1, 0 );
@@ -1301,11 +1304,25 @@ void read_from_buffer( DESCRIPTOR_DATA *d )
             }
             unsigned char cmd = d->inbuf[i+1];
             if ( cmd == DO && d->inbuf[i+2] == TELOPT_MSSP )
+
             {
                 send_mssp(d);
                 i += 3;
                 continue;
             }
+            if ( cmd == DO && (unsigned char)d->inbuf[i+2] == TELOPT_GMCP )
+            {
+                d->gmcp_enabled = TRUE;
+                i += 3;
+                continue;
+            }
+            if ( cmd == DONT && (unsigned char)d->inbuf[i+2] == TELOPT_GMCP )
+            {
+                d->gmcp_enabled = FALSE;
+                i += 3;
+                continue;
+            }
+
             if ( cmd == DO || cmd == DONT || cmd == WILL || cmd == WONT )
             {
                 if ( d->inbuf[i+2] == '\0' )
@@ -1586,8 +1603,11 @@ bool process_output( DESCRIPTOR_DATA *d, bool fPrompt )
  */
 void bust_a_prompt( CHAR_DATA *ch )
 {
+    if ( ch->desc && ch->desc->gmcp_enabled )
+        gmcp_send_char_vitals( ch );
 
     char buf[MAX_STRING_LENGTH];
+
     char buf2[MAX_STRING_LENGTH];
     const char *str;
     const char *i;
@@ -3703,18 +3723,20 @@ int gettimeofday( struct timeval *tp, void *tzp )
 
 int colour( char type, CHAR_DATA *ch, char *string )
 {
-    char    code[ 20 ];
+    char    code[ 32 ];
     char    *p = NULL;
+    bool    is_256 = FALSE;
 
     if( IS_NPC( ch ) )
     return( 0 );
 
+    if ( ch->desc && (ch->desc->gmcp_enabled || (!IS_NPC(ch) && IS_SET(ch->act2, PLR2_ANSI256))) )
+        is_256 = TRUE;
 
         switch( type )
         {
         default:
             sprintf(code, "{%c",type);
-//          sprintf( code, CLEAR );
             break;
         case 'x':
             sprintf( code, CLEAR );
@@ -3771,7 +3793,114 @@ int colour( char type, CHAR_DATA *ch, char *string )
             sprintf( code, "%c", '{' );
             break;
 
+        /* Extended 256-color cases with standard ANSI fallback */
+        case 'v':
+            sprintf( code, is_256 ? C_VIOLET : C_MAGENTA );
+            break;
+        case 'V':
+            sprintf( code, is_256 ? C_B_VIOLET : C_B_MAGENTA );
+            break;
+        case 'P':
+            sprintf( code, is_256 ? C_PINK : C_B_MAGENTA );
+            break;
+        case 'p':
+            sprintf( code, is_256 ? C_PEACH : C_YELLOW );
+            break;
+        case 'o':
+            sprintf( code, is_256 ? C_ORANGE : C_YELLOW );
+            break;
+        case 'O':
+            sprintf( code, is_256 ? C_B_ORANGE : C_B_YELLOW );
+            break;
+        case 'l':
+            sprintf( code, is_256 ? C_LIME : C_B_GREEN );
+            break;
+        case 'L':
+            sprintf( code, is_256 ? C_B_LIME : C_B_GREEN );
+            break;
+        case 't':
+            sprintf( code, is_256 ? C_TEAL : C_CYAN );
+            break;
+        case 'T':
+            sprintf( code, is_256 ? C_TURQUOISE : C_B_CYAN );
+            break;
+        case 'a':
+            sprintf( code, is_256 ? C_AZURE : C_BLUE );
+            break;
+        case 'A':
+            sprintf( code, is_256 ? C_SKY : C_B_CYAN );
+            break;
+        case 'n':
+            sprintf( code, is_256 ? C_NAVY : C_BLUE );
+            break;
+        case 'N':
+            sprintf( code, is_256 ? C_MIDNIGHT : C_BLUE );
+            break;
+        case 'e':
+            sprintf( code, is_256 ? C_EMERALD : C_B_GREEN );
+            break;
+        case 'E':
+            sprintf( code, is_256 ? C_B_EMERALD : C_B_GREEN );
+            break;
+        case 'f':
+            sprintf( code, is_256 ? C_FOREST : C_GREEN );
+            break;
+        case 'F':
+            sprintf( code, is_256 ? C_FERN : C_GREEN );
+            break;
+        case 's':
+            sprintf( code, is_256 ? C_SILVER : C_WHITE );
+            break;
+        case 'S':
+            sprintf( code, is_256 ? C_STEEL : C_D_GREY );
+            break;
+        case 'I':
+            sprintf( code, is_256 ? C_INDIGO : C_BLUE );
+            break;
+        case 'i':
+            sprintf( code, is_256 ? C_ICE : C_B_CYAN );
+            break;
+        case 'j':
+            sprintf( code, is_256 ? C_JADE : C_GREEN );
+            break;
+        case 'J':
+            sprintf( code, is_256 ? C_B_JADE : C_B_GREEN );
+            break;
+        case 'k':
+            sprintf( code, is_256 ? C_KHAKI : C_YELLOW );
+            break;
+        case 'K':
+            sprintf( code, is_256 ? C_GOLD : C_B_YELLOW );
+            break;
+        case 'u':
+            sprintf( code, is_256 ? C_RUST : C_RED );
+            break;
+        case 'U':
+            sprintf( code, is_256 ? C_UMBER : C_RED );
+            break;
+        case 'q':
+            sprintf( code, is_256 ? C_QUARTZ : C_WHITE );
+            break;
+        case 'Q':
+            sprintf( code, is_256 ? C_CREAM : C_B_WHITE );
+            break;
+        case 'h':
+            sprintf( code, is_256 ? C_HONEY : C_YELLOW );
+            break;
+        case 'H':
+            sprintf( code, is_256 ? C_LAVENDER : C_B_MAGENTA );
+            break;
+        case 'd':
+            sprintf( code, is_256 ? C_DUSTY_ROSE : C_RED );
+            break;
+        case 'z':
+            sprintf( code, is_256 ? C_CRIMSON : C_RED );
+            break;
+        case 'Z':
+            sprintf( code, is_256 ? C_SCARLET : C_B_RED );
+            break;
         }
+
     p = code;
     while( *p != '\0' )
     {

--- a/gmcp.c
+++ b/gmcp.c
@@ -1,0 +1,239 @@
+/* gmcp.c - Generic MUD Communication Protocol
+ *
+ * Implements GMCP for Mudlet mapper integration and WoD vitals monitoring.
+ * Protocol format: IAC SB GMCP "Package.Name {json}" IAC SE
+ */
+
+#if defined(macintosh)
+#include <types.h>
+#include <time.h>
+#else
+#include <sys/types.h>
+#include <sys/time.h>
+#include <time.h>
+#endif
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "merc.h"
+#include "telnet.h"
+
+/* Direction abbreviations for the Mudlet mapper */
+static const char *gmcp_dir_name[] = {
+    "n", "e", "s", "w", "u", "d"
+};
+
+
+/* Simple JSON string escaping to avoid breaking client parsers */
+static void escape_json( const char *src, char *dst )
+{
+    if ( !src )
+    {
+        *dst = '\0';
+        return;
+    }
+    while ( *src )
+    {
+        if ( *src == '"' || *src == '\\' )
+        {
+            *dst++ = '\\';
+            *dst++ = *src++;
+        }
+        else if ( *src == '\n' )
+        {
+            *dst++ = '\\';
+            *dst++ = 'n';
+            src++;
+        }
+        else if ( *src == '\r' )
+        {
+            *dst++ = '\\';
+            *dst++ = 'r';
+            src++;
+        }
+        else if ( *src == '\t' )
+        {
+            *dst++ = '\\';
+            *dst++ = 't';
+            src++;
+        }
+        else
+        {
+            *dst++ = *src++;
+        }
+    }
+    *dst = '\0';
+}
+
+/*
+ * Send a GMCP package to a descriptor.
+ * Format: IAC SB GMCP "Package.Name {json_data}" IAC SE
+ */
+void gmcp_send( DESCRIPTOR_DATA *d, const char *package, const char *data )
+{
+    char buf[MAX_STRING_LENGTH * 2];
+    int len;
+
+    if ( !d || !d->gmcp_enabled )
+        return;
+
+    /* Build: IAC SB GMCP <package> <space> <data> IAC SE */
+    buf[0] = (char)IAC;
+    buf[1] = (char)SB;
+    buf[2] = (char)TELOPT_GMCP;
+
+    if ( data && data[0] != '\0' )
+        len = sprintf( buf + 3, "%s %s", package, data );
+    else
+        len = sprintf( buf + 3, "%s", package );
+
+    buf[3 + len] = (char)IAC;
+    buf[4 + len] = (char)SE;
+
+    write_to_buffer( d, buf, 5 + len );
+}
+
+/*
+ * Send Room.Info — the core mapper packet.
+ * Called whenever a player enters a room (do_look, char_to_room, etc.)
+ */
+void gmcp_send_room( CHAR_DATA *ch )
+{
+    char buf[MAX_STRING_LENGTH * 2];
+    char exits_buf[MAX_STRING_LENGTH];
+    char escaped_name[MAX_STRING_LENGTH];
+    char escaped_area[MAX_STRING_LENGTH];
+    ROOM_INDEX_DATA *room;
+    int i;
+    bool first_exit = TRUE;
+
+    if ( !ch || !ch->desc || !ch->desc->gmcp_enabled || !ch->in_room )
+        return;
+
+    room = ch->in_room;
+
+    /* Build exits JSON object */
+    strcpy( exits_buf, "{" );
+    for ( i = 0; i < 6; i++ )
+    {
+        if ( room->exit[i] != NULL
+        &&   room->exit[i]->u1.to_room != NULL
+        &&   !IS_SET(room->exit[i]->exit_info, EX_CLOSED) )
+        {
+            char exit_entry[128];
+            sprintf( exit_entry, "%s\"%s\":%d",
+                first_exit ? "" : ",",
+                gmcp_dir_name[i],
+                room->exit[i]->u1.to_room->vnum );
+            strcat( exits_buf, exit_entry );
+            first_exit = FALSE;
+        }
+    }
+    strcat( exits_buf, "}" );
+
+    /* Escape string fields safely */
+    escape_json( room->name ? room->name : "Unknown", escaped_name );
+    escape_json( (room->area && room->area->name) ? room->area->name : "Unknown", escaped_area );
+
+    /* Build the full Room.Info JSON */
+    sprintf( buf,
+        "{\"num\":%d,"
+         "\"name\":\"%s\","
+         "\"area\":\"%s\","
+         "\"environment\":\"%s\","
+         "\"exits\":%s}",
+        room->vnum,
+        escaped_name,
+        escaped_area,
+        sector_name( room->sector_type ),
+        exits_buf );
+
+    gmcp_send( ch->desc, "Room.Info", buf );
+}
+
+/*
+ * Send Char.Vitals — health, mana, movement, and World of Darkness stats.
+ * Called on prompt, after combat, regenerate tick, etc.
+ */
+void gmcp_send_char_vitals( CHAR_DATA *ch )
+{
+    char buf[MAX_STRING_LENGTH];
+    int willpower = 0;
+    int max_willpower = 0;
+    int bloodpool = 0;
+    int max_bloodpool = 0;
+    int rage = 0;
+    int max_rage = 0;
+    int gnosis = 0;
+    int max_gnosis = 0;
+    int quintessence = 0;
+    int max_quintessence = 0;
+    int paradox = 0;
+
+    if ( !ch || !ch->desc || !ch->desc->gmcp_enabled || IS_NPC(ch) )
+        return;
+
+    willpower = ch->cswillpower;
+    max_willpower = ch->csmax_willpower;
+
+    if ( ch->pcdata )
+    {
+        bloodpool = ch->pcdata->csbloodpool;
+        max_bloodpool = ch->pcdata->csmax_bloodpool;
+        rage = ch->pcdata->rage[0];
+        max_rage = ch->pcdata->rage[1];
+        gnosis = ch->pcdata->gnosis[0];
+        max_gnosis = ch->pcdata->gnosis[1];
+    }
+
+    quintessence = ch->quintessence;
+    max_quintessence = ch->max_quintessence;
+    paradox = ch->paradox;
+
+    sprintf( buf,
+        "{\"hp\":%d,\"maxhp\":%d,"
+         "\"mana\":%d,\"maxmana\":%d,"
+         "\"move\":%d,\"maxmove\":%d,"
+         "\"willpower\":%d,\"maxwillpower\":%d,"
+         "\"bloodpool\":%d,\"maxbloodpool\":%d,"
+         "\"rage\":%d,\"maxrage\":%d,"
+         "\"gnosis\":%d,\"maxgnosis\":%d,"
+         "\"quintessence\":%d,\"maxquintessence\":%d,"
+         "\"paradox\":%d}",
+        ch->hit, ch->max_hit,
+        ch->mana, ch->max_mana,
+        ch->move, ch->max_move,
+        willpower, max_willpower,
+        bloodpool, max_bloodpool,
+        rage, max_rage,
+        gnosis, max_gnosis,
+        quintessence, max_quintessence,
+        paradox );
+
+    gmcp_send( ch->desc, "Char.Vitals", buf );
+}
+
+/*
+ * Helper: sector type to environment name string for mapper coloring.
+ */
+const char *sector_name( int sector )
+{
+    switch ( sector )
+    {
+        case SECT_INSIDE:       return "indoors";
+        case SECT_CITY:         return "city";
+        case SECT_FIELD:        return "field";
+        case SECT_FOREST:       return "forest";
+        case SECT_HILLS:        return "hills";
+        case SECT_MOUNTAIN:     return "mountain";
+        case SECT_WATER_SWIM:   return "shallowwater";
+        case SECT_WATER_NOSWIM: return "water";
+        case SECT_AIR:          return "air";
+        case SECT_DESERT:       return "desert";
+        case SECT_WATER_DROWN:  return "underwater";
+        case SECT_HOT:          return "lava";
+        case SECT_COLD:         return "tundra";
+        case SECT_NODE:         return "node";
+        default:                return "unknown";
+    }
+}

--- a/handler.c
+++ b/handler.c
@@ -1899,7 +1899,11 @@ void char_to_room( CHAR_DATA *ch, ROOM_INDEX_DATA *pRoomIndex )
     if (is_affected(ch, gsn_gift_lambentfire))
       ch->in_room->light += 2;
 
+    if ( ch->desc && ch->desc->gmcp_enabled )
+        gmcp_send_room( ch );
+
     return;
+
 }
 
 

--- a/merc.h
+++ b/merc.h
@@ -259,24 +259,61 @@ typedef void ROOM_FUN	args( ( ROOM_INDEX_DATA *room, char *argument ) );
 /*
  * Colour stuff by Lope of Loping Through The MUD
  */
-#define CLEAR       "[0m"      /* Resets Colour    */
-#define C_RED       "[0;31m"   /* Normal Colours   */
-#define C_GREEN     "[0;32m"
-#define C_YELLOW    "[0;33m"
-#define C_BLUE      "[0;34m"
-#define C_MAGENTA   "[0;35m"
-#define C_CYAN      "[0;36m"
-#define C_WHITE     "[0;37m"
-#define C_D_GREY    "[1;30m"   /* Light Colors     */
-#define C_B_RED     "[1;31m"
-#define C_B_GREEN   "[1;32m"
-#define C_B_YELLOW  "[1;33m"
-#define C_B_BLUE    "[1;34m"
-#define C_B_MAGENTA "[1;35m"
-#define C_B_CYAN    "[1;36m"
-#define C_B_WHITE   "[1;37m"
+#define CLEAR       "\033[0m"      /* Resets Colour    */
+#define C_RED       "\033[0;31m"   /* Normal Colours   */
+#define C_GREEN     "\033[0;32m"
+#define C_YELLOW    "\033[0;33m"
+#define C_BLUE      "\033[0;34m"
+#define C_MAGENTA   "\033[0;35m"
+#define C_CYAN      "\033[0;36m"
+#define C_WHITE     "\033[0;37m"
+#define C_D_GREY    "\033[1;30m"   /* Light Colors     */
+#define C_B_RED     "\033[1;31m"
+#define C_B_GREEN   "\033[1;32m"
+#define C_B_YELLOW  "\033[1;33m"
+#define C_B_BLUE    "\033[38;5;68m" /* Softer Cornflower Blue */
+#define C_B_MAGENTA "\033[1;35m"
+#define C_B_CYAN    "\033[1;36m"
+#define C_B_WHITE   "\033[1;37m"
 
-#define MAX_RANDOM 14
+/* Extended 256-Color Palette */
+#define C_VIOLET       "\033[38;5;135m"
+#define C_B_VIOLET     "\033[38;5;171m"
+#define C_PINK         "\033[38;5;198m"
+#define C_PEACH        "\033[38;5;222m"
+#define C_ORANGE       "\033[38;5;208m"
+#define C_B_ORANGE     "\033[38;5;214m"
+#define C_LIME         "\033[38;5;118m"
+#define C_B_LIME       "\033[38;5;120m"
+#define C_TEAL         "\033[38;5;30m"
+#define C_TURQUOISE    "\033[38;5;44m"
+#define C_AZURE        "\033[38;5;33m"
+#define C_SKY          "\033[38;5;117m"
+#define C_NAVY         "\033[38;5;18m"
+#define C_MIDNIGHT     "\033[38;5;17m"
+#define C_EMERALD      "\033[38;5;35m"
+#define C_B_EMERALD    "\033[38;5;48m"
+#define C_FOREST       "\033[38;5;22m"
+#define C_FERN         "\033[38;5;28m"
+#define C_SILVER       "\033[38;5;249m"
+#define C_STEEL        "\033[38;5;245m"
+#define C_INDIGO       "\033[38;5;62m"
+#define C_ICE          "\033[38;5;159m"
+#define C_JADE         "\033[38;5;29m"
+#define C_B_JADE       "\033[38;5;42m"
+#define C_KHAKI        "\033[38;5;143m"
+#define C_GOLD         "\033[38;5;178m"
+#define C_RUST         "\033[38;5;130m"
+#define C_UMBER        "\033[38;5;94m"
+#define C_QUARTZ       "\033[38;5;230m"
+#define C_CREAM        "\033[38;5;229m"
+#define C_HONEY        "\033[38;5;172m"
+#define C_LAVENDER     "\033[38;5;183m"
+#define C_DUSTY_ROSE   "\033[38;5;174m"
+#define C_CRIMSON      "\033[38;5;160m"
+#define C_SCARLET      "\033[38;5;196m"
+
+#define MAX_RANDOM 49
 extern char randomcolors[MAX_RANDOM + 2];
 
 
@@ -624,6 +661,7 @@ struct  descriptor_data
     void *      pEdit;      /* OLC */
     char **     pString;    /* OLC */
     int         editor;     /* OLC */
+    bool        gmcp_enabled; /* Client supports GMCP */
 };
 
 
@@ -1965,6 +2003,8 @@ struct  kill_data
 #define PLR2_DEBUG        (O) // Flag char a debugger
 #define PLR2_DEBUGMSG     (P) // Show debug messages
 #define PLR2_RP_AVAILABLE (Q) // Show player looking for RP
+#define PLR2_ANSI256      (R) // Client supports 256 colors manually
+
 
 
 /* RT comm flags -- may be used on both mobs and chars */
@@ -3730,6 +3770,13 @@ int colour      args( ( char type, CHAR_DATA *ch, char *string ) );
 void    colourconv  args( ( char *buffer, const char *txt, CHAR_DATA *ch ) );
 void    send_to_char_bw args( ( const char *txt, CHAR_DATA *ch ) );
 void    page_to_char_bw args( ( const char *txt, CHAR_DATA *ch ) );
+
+/* gmcp.c */
+void    gmcp_send           args( ( DESCRIPTOR_DATA *d, const char *package, const char *data ) );
+void    gmcp_send_room      args( ( CHAR_DATA *ch ) );
+void    gmcp_send_char_vitals args( ( CHAR_DATA *ch ) );
+const char * sector_name    args( ( int sector ) );
+
 
 /* db.c */
 void    reset_area      args( ( AREA_DATA * pArea ) );      /* OLC */

--- a/recycle.c
+++ b/recycle.c
@@ -131,8 +131,10 @@ DESCRIPTOR_DATA *new_descriptor(void)
     d->showstr_point = NULL;
     d->outsize  = 2000;
     d->outbuf   = alloc_mem( d->outsize );
+    d->gmcp_enabled = FALSE;
 
     return d;
+
 }
 
 void free_descriptor(DESCRIPTOR_DATA *d)

--- a/telnet.h
+++ b/telnet.h
@@ -68,6 +68,8 @@ char *telcmds[] = {
 #define	TELOPT_EOR	25	/* end or record */
 #define TELOPT_EXOPL	255	/* extended-options-list */
 #define TELOPT_MSSP	70	/* mud server status protocol */
+#define TELOPT_GMCP	201	/* generic mud communication protocol */
+
 
 #define MSSP_VAR	1
 #define MSSP_VAL	2


### PR DESCRIPTION
ANSI True Color support added. Also GMCP which allows out-of-stream data communication between blah blah yadda yadda.

The MUD will now send supporting clients the following information:

Room.Info: Name, num, area, environment, exits. For Mappers! Mapper not included.
Char.Vitals: Hp, Mana, Movement, willpower, bloodpool, rage, gnosis, quintessence, paradox. For graphical UI nonsense and statusbars and etc. Etc not included.

For those interested in scripting and building a mapper or UI for Haven, the data is being sent. The actual implementation of the scripts within the client are not my job.

<img width="916" height="453" alt="image" src="https://github.com/user-attachments/assets/41c79f69-49db-4cb8-9999-ada702cd716b" />
