### PR TITLE
Removed error message from center(), falls back to empty string

### DIFF
--- a/handler.c
+++ b/handler.c
@@ -4366,11 +4366,7 @@ char *center( char *argument, int width, char *fill )
         fill = " ";
 
     if( !argument )
-    {
-        sprintf( log_buf, "ERROR! Please note an imm if you see this message.\n\r"
-                          "Please include EXACTLY what you did before you got this message.\n\r");
-        return log_buf;
-    }
+        argument = "";
 
     length = strlen_color( argument );
 


### PR DESCRIPTION
because this is dumb.

<img width="1019" height="169" alt="image" src="https://github.com/user-attachments/assets/a912f629-f8a0-4347-b165-f7561fc5a12e" />
