### PR TITLE
[WIP] Moved from IC-hours based roleplay exp to activity-based

### DIFF
--- a/act_comm.c
+++ b/act_comm.c
@@ -1053,7 +1053,10 @@ void do_say( CHAR_DATA *ch, char *argument )
     act( "{xYou say '{w$T{x'", ch, NULL, argument, TO_CHAR );
     RECORD_TO_REPLAYROOM=FALSE;
     if (!IS_NPC(ch) && IS_SET(ch->act, PLR_IC))
+    {
         ch->pcdata->last_pose = 0;
+        gain_rp_activity(ch, argument);
+    }
     if ( !IS_NPC(ch) )
     {
         CHAR_DATA *mob, *mob_next;
@@ -1219,6 +1222,9 @@ void do_whisper( CHAR_DATA *ch, char *argument )
     if (!IS_NPC(ch) && IS_NPC(victim) && HAS_TRIGGER_MOB(victim,TRIG_SPEECH) &&
         (victim->position > POS_SLEEPING) && (victim->position != POS_FIGHTING))
         p_act_trigger( argument, victim,NULL, NULL, ch, NULL, NULL, TRIG_SPEECH );
+
+    if (!IS_NPC(ch) && IS_SET(ch->act, PLR_IC))
+        gain_rp_activity(ch, argument);
 
 }// do_whisper
 
@@ -1464,7 +1470,10 @@ void do_emote( CHAR_DATA *ch, char *argument )
         mob->pcdata->room_last_pose = 0;
     }
     if (!IS_NPC(ch) && IS_SET(ch->act, PLR_IC))
+    {
         ch->pcdata->last_pose = 0;
+        gain_rp_activity(ch, argument);
+    }
 
     return;
 }
@@ -1564,7 +1573,10 @@ void do_pmote( CHAR_DATA *ch, char *argument )
         mob->pcdata->room_last_pose = 0;
     }
     if (!IS_NPC(ch) && IS_SET(ch->act, PLR_IC))
+    {
         ch->pcdata->last_pose = 0;
+        gain_rp_activity(ch, argument);
+    }
 
     }
 

--- a/interp.c
+++ b/interp.c
@@ -514,6 +514,9 @@ bool check_social( CHAR_DATA *ch, char *command, char *argument )
     }
     }
 
+    if (!IS_NPC(ch) && IS_SET(ch->act, PLR_IC))
+        gain_social_activity(ch);
+
     return TRUE;
 }
 

--- a/merc.h
+++ b/merc.h
@@ -2545,6 +2545,8 @@ struct  pc_data
 /* Matt's anti rp milking code. */
     int         last_pose;
     int         room_last_pose;
+    long        rp_activity;
+    int         rp_lines;
 
 // replay buffers
     unsigned int        next_replaytell;
@@ -4543,3 +4545,13 @@ extern      ROOM_INDEX_DATA *   room_index_hash [MAX_KEY_HASH];
 extern      char            *help_list  [MAX_HELP];
 
 CMD_DATA *cmd_lookup(const char *name );
+
+/* Dawn of Time style RPEXP constants and functions */
+#define MAX_RP_ACTIVITY         3000
+#define RP_EXP_MULTIPLIER       8
+#define RP_QP_DIVISOR           4
+#define RP_TICK_DRAIN_FRACTION  10
+#define RP_TICK_DRAIN_MIN       50
+
+void gain_rp_activity(CHAR_DATA *ch, char *argument);
+void gain_social_activity(CHAR_DATA *ch);

--- a/rpexp.c
+++ b/rpexp.c
@@ -1,0 +1,62 @@
+#if defined(macintosh)
+#include <types.h>
+#include <time.h>
+#else
+#include <sys/types.h>
+#include <sys/time.h>
+#endif
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <time.h>
+#include "merc.h"
+
+void gain_rp_activity(CHAR_DATA *ch, char *argument)
+{
+    if (IS_NPC(ch))
+        return;
+
+    if (!IS_SET(ch->act, PLR_IC))
+        return;
+
+    if (argument == NULL || argument[0] == '\0')
+        return;
+
+    // Increment line count
+    ch->pcdata->rp_lines++;
+
+    // Base activity points for any valid RP line
+    long points = 5;
+
+    // Bonus points based on length (1 point per 10 characters)
+    int len = strlen(argument);
+    points += len / 10;
+
+    // Cap the points from a single RP action to prevent paste abuse
+    if (points > 100)
+        points = 100;
+
+    ch->pcdata->rp_activity += points;
+
+    // Cap the total activity pool
+    if (ch->pcdata->rp_activity > MAX_RP_ACTIVITY)
+        ch->pcdata->rp_activity = MAX_RP_ACTIVITY;
+}
+
+void gain_social_activity(CHAR_DATA *ch)
+{
+    if (IS_NPC(ch))
+        return;
+
+    if (!IS_SET(ch->act, PLR_IC))
+        return;
+
+    // Small fixed bonus for using a social
+    long points = 5;
+
+    ch->pcdata->rp_activity += points;
+
+    // Cap the total activity pool
+    if (ch->pcdata->rp_activity > MAX_RP_ACTIVITY)
+        ch->pcdata->rp_activity = MAX_RP_ACTIVITY;
+}

--- a/save.c
+++ b/save.c
@@ -182,7 +182,9 @@ void fwrite_char( CHAR_DATA *ch, FILE *fp )
         fprintf( fp, "ICtotal %ld\n",ch->pcdata->IC_total);
         fprintf( fp, "ICrank %ld\n",ch->pcdata->IC_rank);
         fprintf( fp, "ICgoal %ld\n",ch->pcdata->IC_goal);
-        fprintf (fp, "Influ %d\n", ch->pcdata->influenced);
+        fprintf( fp, "Influ %d\n", ch->pcdata->influenced);
+        fprintf( fp, "RPAct %ld\n", ch->pcdata->rp_activity);
+        fprintf( fp, "RPLin %d\n", ch->pcdata->rp_lines);
 
         if(ch->pcdata->registered)
         {
@@ -911,6 +913,8 @@ bool load_char_obj( DESCRIPTOR_DATA *d, char *name )
     ch->pcdata->condition[COND_HUNGER]  = 48;
     ch->pcdata->last_pose = 5;
     ch->pcdata->room_last_pose = 5;
+    ch->pcdata->rp_activity = 0;
+    ch->pcdata->rp_lines = 0;
     ch->pcdata->security        = 0;    /* OLC */
     ch->pcdata->immclass = 0;
     ch->pcdata->sect        = 0;
@@ -1621,6 +1625,8 @@ void fread_char( CHAR_DATA *ch, FILE *fp )
         KEY( "Remorts", ch->remorts,        fread_number( fp ) );
         KEY( "Renown",  ch->renown, fread_number( fp ) );
                 KEY( "Resis",     ch->res_flags,        fread_flag( fp ) );
+        KEY( "RPAct",   ch->pcdata->rp_activity,        fread_number( fp ) );
+        KEY( "RPLin",   ch->pcdata->rp_lines,           fread_number( fp ) );
 
         if ( !str_cmp( word, "Room" ) )
         {

--- a/update.c
+++ b/update.c
@@ -1134,68 +1134,37 @@ void char_update( void )
         }
     }   /* add rank gain and goal gain here */
         }
-    if(ch->qpoints < MAX_QPOINTS)
-    {
-        ichours = ch->pcdata->IC_total/60;
-
-            qpgain = number_range(ichours, ichours/2 + 8);
-        if (ichours >= 100)
-            qpgain = number_range(ichours/2, ichours/4 + 8);
-        if (ichours > 300)
-            qpgain = number_range(ichours/4, ichours/8 + 8);
-        if (ichours > 600)
-            qpgain = number_range(ichours/8, ichours/16 + 8);
-
-       switch (ch->pcdata->room_last_pose) {
-           case 0: case 1:
-           case 2: case 3: qpgain = 3*qpgain/2;break;
-           case 4: case 5: break;
-           case 6: case 7: qpgain = qpgain/2;break;
-           default: qpgain = 4;break;
-       }
-        // Doing math ahead of time so variables match
-        qpaward = UMIN(200+ch->remorts, qpgain);
-        if (qpaward > 50)
-          qpaward = 50;
-
-       if (ch->pcdata->last_pose < 8)
+        if (!IS_NPC(ch))
         {
+            long drain_amount = ch->pcdata->rp_activity / RP_TICK_DRAIN_FRACTION;
+            if (drain_amount < RP_TICK_DRAIN_MIN)
+                drain_amount = UMIN(ch->pcdata->rp_activity, RP_TICK_DRAIN_MIN);
 
-        // Line for this into gxp as well
-             global_xp += qpaward*xpmult;
-             gain_qp(ch, qpaward);
+            if (drain_amount > 0)
+            {
+                ch->pcdata->rp_activity -= drain_amount;
+
+                /* Calculate QP Reward */
+                qpaward = drain_amount / RP_QP_DIVISOR;
+                qpaward = UMIN(50, qpaward);
+
+                if (qpaward > 0 && ch->qpoints < MAX_QPOINTS)
+                {
+                    global_xp += qpaward * xpmult;
+                    gain_qp(ch, qpaward);
+                }
+
+                /* Calculate EXP Reward */
+                rpxp = drain_amount * RP_EXP_MULTIPLIER;
+                rpaddictxp = get_addict_bonus(ch, rpxp);
+                rpxp += rpaddictxp;
+                rpxp = UMIN((370 + ch->remorts) * 2, rpxp);
+
+                gain_exp(ch, rpxp);
+                if (doubleexp)
+                    gain_exp(ch, rpxp);
+            }
         }
-
-/*
-       if (doubleexp)
-           {
-           qpaward = qpaward*2;
-           global_xp -= qpaward*2;
-
-            if (global_qp > 40000)
-              {
-                 qpaward = qpaward*2;
-                 global_qp -= qpaward;
-              }
-           ch->qpoints += qpaward;
-           ch->totalqpoints += qpaward;
-       }
-*/
-
-
-        }
-
-
-/* New experience code added by Sengir to help out the hardcore RP'ers, Revised by Matthew
-   Calculation: exp random 50-rphrs+100 max 370+remorts*2 */
-
-   ichours = (ch->played + (int) (current_time - ch->logon)) / 3600;
-   rpxp = UMIN( (370 + ch->remorts)*2, number_range( ichours/8, (ichours/6 + ch->roleplaying)));
-   rpaddictxp = get_addict_bonus(ch, rpxp);
-   rpxp += rpaddictxp;
-   gain_exp(ch, rpxp);
-   if (doubleexp)
-      gain_exp( ch, UMIN( (370 + ch->remorts)*2, number_range( ichours/8, (ichours/6 + ch->roleplaying))*xpawardmult));
     }
 
     if(ch->race == race_lookup("vampire") || ch->race == race_lookup("methuselah"))


### PR DESCRIPTION
> I think some of the older players with hundreds of hours IC might be a little salty that their IC hours now mean nothing. What can we do about this?


This is a very common and valid challenge when migrating to activity-based systems. Veteran players who have dedicated hundreds of hours building their characters can feel that their legacy is being devalued. 

To resolve this, we can integrate their legacy **lifetime IC hours** (`ichours = ch->pcdata->IC_total / 60`) into the new RPEXP system in a way that respects their history **without** re-introducing passive farming or hyper-inflation.

Here are four elegant options we could implement:

---

### Option 1: Legacy Pool Cap Expansion (Highly Recommended)
We can scale their maximum activity pool cap (`MAX_RP_ACTIVITY`) based on their lifetime IC hours.
*   **How it works**: Instead of a flat `3,000` point cap for everyone, a player's cap scales:
    $$\text{Max Pool} = 3000 + \left(\frac{\text{IC Hours}}{100} \times 500\right) \quad (\text{capped at } 6000)$$
*   **Why it works**: A veteran with 600 IC hours can "bank" up to **6,000 points** during a massive roleplay scene. This means their trickle-down rewards will continue to pay out for twice as long after they log off or pause, without inflating the maximum per-tick payouts.
*   **Pros**: Highly satisfying for veterans; encourages long, deep roleplay sessions; completely maintains economic balance.

---

### Option 2: The Legacy Multiplier (Faster Pool Building)
We can apply a small scaling bonus to the activity points earned per emote based on their legacy.
*   **How it works**: The points earned for speech/emotes are multiplied by a legacy factor:
    $$\text{Legacy Factor} = 1.0 + \left(\frac{\text{IC Hours}}{1000}\right) \quad (\text{capped at } 1.5\text{x})$$
*   **Why it works**: A veteran with 500 IC hours gets a **1.5x multiplier** on all roleplay activity points. For a detailed 450-character emote, they would earn 75 points instead of 50 points, letting them fill their pool faster with less effort.
*   **Pros**: Makes veterans feel their "roleplay experience" makes them highly efficient at earning rewards.

---

### Option 3: Higher Reward Caps (Faster Payouts)
We can raise the per-tick caps on QP and EXP rewards based on their legacy.
*   **How it works**:
    *   **QP Tick Cap**: Instead of a flat `50` QP/tick, it scales to `50 + (IC Hours / 10)`, capped at `100` QP/tick.
    *   **EXP Tick Cap**: Instead of `(370 + remorts) * 2`, we add a legacy offset: `((370 + remorts) * 2) + (IC Hours * 2)`.
*   **Why it works**: Veterans can drain their accumulated activity pool much faster, getting their leveling progression and QP payouts in larger bursts per minute.
*   **Pros**: Makes legacy status feel immediately powerful in term of leveling speed.

---

### Option 4: Legacy Conversion Efficiency Bonus
We can increase the conversion efficiency of drained points into EXP and QP for veterans.
*   **How it works**: Instead of a flat conversion rate, veterans get slightly more output per point drained:
    *   **EXP Multiplier**: Scales from `8` up to `12` based on IC hours: `8 + (IC Hours / 100)`.
    *   **QP Divisor**: Decreases from `4` down to `3` (making QP cheaper): `MAX(3, 4 - (IC Hours / 400))`.
*   **Why it works**: Veteran characters literally get more EXP and QP out of every single activity point they spend.

---

@RedRobeGilean  Pick an option and tell me which to code so your RP hours don't become useless e-peen points.